### PR TITLE
Add org.freedesktop.Platform.ffmpeg-full extension

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -36,6 +36,10 @@ add-extensions:
     merge-dirs: ladspa;lv2;vst;vst3
     subdirectories: true
     no-autodownload: true
+  org.freedesktop.Platform.ffmpeg-full:
+    version: '22.08'
+    autodownload: true
+    autodelete: false
 
 cleanup:
   - /include


### PR DESCRIPTION
This PR adds the `org.freedesktop.Platform.ffmpeg-full` extension. This is so Tenacity can support more codecs via FFmpeg. It is also intended to resolve https://codeberg.org/tenacityteam/tenacity/issues/179, which involves the use of a non-free(?) codec.

This bit came from Oro in the Tenacity Matrix room. All credits go to them.