### PR TITLE
Update to Tenacity 1.3

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -191,8 +191,8 @@ modules:
     sources:
       - type: git
         url: https://codeberg.org/tenacityteam/tenacity.git
-        tag: v1.3-beta3-1
-        commit: e7e6019886c8fe4e1a9ae73e34c26eb48b60e6c2
+        tag: v1.3
+        commit: 3a7fda25b7171a37977016aeb70ec7c8b9258a62
       - type: script
         dest-filename: tenacity.sh
         commands:

--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -191,8 +191,8 @@ modules:
     sources:
       - type: git
         url: https://codeberg.org/tenacityteam/tenacity.git
-        tag: v1.3
-        commit: 3a7fda25b7171a37977016aeb70ec7c8b9258a62
+        tag: v1.3-flatpak
+        commit: b5d611acd6612a65c0b34266cf7bbc25ae15e9af
       - type: script
         dest-filename: tenacity.sh
         commands:


### PR DESCRIPTION
`v1.3` has already been tagged in Codeberg. Go ahead and upgrade the Flatpak to 1.3.

**Note**: from here on out, we will only package stable versions as is expected.