### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -12,7 +12,12 @@ finish-args:
   - --share=network # Tenacity uses network sockets for IPC
   - --socket=pulseaudio
   - --device=all # ALSA
-  - --filesystem=host
+  - --filesystem=home
+  - --filesystem=/media
+  - --filesystem=/mnt
+  - --filesystem=/run/media
+  - --filesystem=/var/run/media
+  - --filesystem=/var/mnt
   # mod-script-pipe provides named pipes in /tmp
   - --filesystem=/tmp
   - --env=LD_LIBRARY_PATH=/app/lib/audacity


### PR DESCRIPTION
it should not have host access

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt