### PR TITLE
Enable SBSMS in builds

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -181,6 +181,7 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DWX_CONFIG=/app/bin/wx-config
+      - -DSBSMS=On
     post-install:
       - install -d /app/extensions/Plugins
       - install -Dm755 ../tenacity.sh /app/bin/tenacity.sh


### PR DESCRIPTION
Resolves: https://codeberg.org/tenacityteam/tenacity/issues/303

This PR enables SBSMS in the Flatpak, allowing for high quality stretching. This comes at the request of a user who wants higher quality stretching and pitch shifting/tempo changing.