### PR TITLE
Attempt to speed up and slim down builds

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -52,19 +52,18 @@ cleanup:
 
 modules:
   - name: wxwidgets
-    rm-configure: true
+    buildsystem: cmake-ninja
     config-opts:
-      - --with-libpng
-      - --with-zlib
-      - --with-cxx=17
-      - --disable-sdltest
-      - --disable-webview
-      - --disable-webviewwebkit
-      - --disable-ribbon
-      - --disable-propgrid
-      - --disable-richtext
-      - --with-expat=builtin
-      - --with-libiconv=/usr
+      - -DwxUSE_LIBPNG=sys
+      - -DwxUSE_ZLIB=sys
+      - -DwxBUILD_CXX_STANDARD=17
+      - -DwxBUILD_TESTS=OFF
+      - -DwxUSE_WEBVIEW=OFF
+      - -DwxUSE_WEBVIEW_WEBKIT=OFF
+      - -DwxUSE_RIBBON=OFF
+      - -DwxUSE_PROPGRID=OFF
+      - -DwxUSE_RICHTEXT=OFF
+      - -DwxUSE_EXPAT=sys
     cleanup:
       - /share/bakefile
     sources:
@@ -183,6 +182,7 @@ modules:
       - /bin
 
   - name: soundtouch
+    buildsystem: cmake-ninja
     sources:
       - type: git
         url: https://codeberg.org/soundtouch/soundtouch.git

--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -54,6 +54,8 @@ modules:
   - name: wxwidgets
     buildsystem: cmake-ninja
     config-opts:
+      # Most of these options disable a lot of the toolkit. We might add more
+      # as Tenacity changes.
       - -DwxUSE_LIBPNG=sys
       - -DwxUSE_ZLIB=sys
       - -DwxBUILD_CXX_STANDARD=17
@@ -63,7 +65,30 @@ modules:
       - -DwxUSE_RIBBON=OFF
       - -DwxUSE_PROPGRID=OFF
       - -DwxUSE_RICHTEXT=OFF
+      - -DwxUSE_RICHTEXT_XML_HANDLER=OFF
       - -DwxUSE_EXPAT=sys
+      - -DwxUSE_MDI=OFF
+      - -DwxUSE_STC=OFF
+      - -DwxUSE_MEDIACTRL=OFF
+      - -DwxUSE_PROTOCOL=OFF
+      - -DwxUSE_FS_INET=OFF
+      - -DwxUSE_URL=OFF
+      - -DwxUSE_MDI_ARCHITECTURE=OFF
+      - -DwxUSE_LIBJPEG=OFF
+      - -DwxUSE_LIBTIFF=OFF
+      - -DwxUSE_NANOSVG=OFF
+      - -DwxUSE_SVG=OFF
+      - -DwxUSE_DIALUP_MANAGER=OFF
+      - -DwxUSE_DYNAMIC_LOADER=OFF
+      - -DwxUSE_LIBGNOMEVFS=OFF # Probably unnecessary, but just in case
+      - -DwxUSE_AUI=OFF
+      # FIXME: Uncomment these build options once the next stable release is
+      # out. See https://codeberg.org/tenacityteam/tenacity/pulls/525 for more
+      # details.
+      # - -DwxUSE_STACKWALKER=OFF
+      # - -DwxUSE_DEBUGREPORT=OFF
+      # Disabling XRC causes issues ('cannot find -lwxxml')
+      # - -DwxUSE_XRC=OFF
     cleanup:
       - /share/bakefile
     sources:


### PR DESCRIPTION
[This tenacity-legacy PR](https://github.com/tenacityteam/tenacity-legacy/pull/609) makes several changes to try to speed up Flatpak builds. This PR carries over the Flatpak manifest work and adds additional changes such as the following:

* Disabling some protocol support (namely internet protocols)
* Disabling dialup management support
* Disabling wxPlugin{Manager,Library}.
* Disabling SVG DC and rasterization support
* Disabling AUI
* Disabling libgnomevfs support (probably unnecessary but a good measure just in case)
* Disabling support for certain file formats (JPEG, TIFF).

Changes made to Tenacity itself and vcpkg will be investigated and potentially remerged where appropriate.