### PR TITLE
Fix Vamp SDK URL

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -154,7 +154,7 @@ modules:
     no-parallel-make: true
     sources:
       - type: git
-        url: https://github.com/c4dm/vamp-plugin-sdk.git
+        url: https://github.com/vamp-plugins/vamp-plugin-sdk.git
         tag: vamp-plugin-sdk-v2.10
         commit: 67adfc2bf9486912a0fce5123cf54360ea2678bc
     cleanup:


### PR DESCRIPTION
Updates the Vamp SDK repo to the mainstream GitHub repo.