### PR TITLE
Update FFmpeg to 6.1.1

### DIFF
--- a/deps/ffmpeg.yml
+++ b/deps/ffmpeg.yml
@@ -106,7 +106,7 @@ cleanup:
   - /share/ffmpeg/examples
 sources:
   - type: archive
-    url: https://ffmpeg.org/releases/ffmpeg-6.0.tar.xz
-    sha256: 57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082
+    url: https://ffmpeg.org/releases/ffmpeg-6.1.1.tar.xz
+    sha256: 8684f4b00f94b85461884c3719382f1261f0d9eb3d59640a1f4ac0873616f968
   - type: patch
     path: ffmpeg-as-fix.patch


### PR DESCRIPTION
Updates the bundled version of FFmpeg to 6.1.1. We still officially ship FFmpeg 6.0, but FFmpeg 6.1.1 should still work without issue.