### PR TITLE
Remove '-mixxxdj' from PortMidi

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -117,7 +117,7 @@ modules:
           type: git
           tag-pattern: ^([\d.]+)$
 
-  - name: portmidi-mixxxdj
+  - name: portmidi
     buildsystem: cmake-ninja
     sources:
       - type: git


### PR DESCRIPTION
We use upstream PortMidi instead of Mixxx's version, so remove the '-mixxxdj' suffix from PortMidi.