### PR TITLE
Update suil to 0.10.20

### DIFF
--- a/deps/suil.json
+++ b/deps/suil.json
@@ -1,10 +1,8 @@
 {
       "name": "suil",
-      "buildsystem": "simple",
-      "build-commands": [
-        "python3 ./waf configure --prefix=/app",
-        "python3 ./waf build -j $FLATPAK_BUILDER_N_JOBS",
-        "python3 ./waf install"
+      "buildsystem": "meson",
+      "config_opts": [
+        "--prefix=/app"
       ],
       "cleanup": [
         "/include",
@@ -13,12 +11,12 @@
       "sources": [
         {
           "type": "archive",
-          "url": "http://download.drobilla.net/suil-0.10.10.tar.bz2",
-          "sha256": "750f08e6b7dc941a5e694c484aab02f69af5aa90edcc9fb2ffb4fb45f1574bfb"
+          "url": "http://download.drobilla.net/suil-0.10.20.tar.xz",
+          "sha256": "334a3ed3e73d5e17ff400b3db9801f63809155b0faa8b1b9046f9dd3ffef934e"
         }
       ],
       "post-install": [
-        "install -Dm644 -t /app/share/licenses/suil COPYING"
+        "install -Dm644 -t /app/share/licenses/suil ../COPYING"
       ],
       "cleanup": [
         "/bin",


### PR DESCRIPTION
Updates suil to the latest version. Previously, suil was at 0.10.10, released back in the start of 2021. It appears that Flathubbot missed this, so we'll need to update suil manually.

Because suil switched to meson from waf, I also switched the build system to meson as well.