### PR TITLE
Fix generic Wayland icon

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -4,6 +4,7 @@ runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: tenacity.sh
 rename-icon: tenacity
+copy-icon: true
 rename-desktop-file: tenacity.desktop
 rename-appdata-file: tenacity.metainfo.xml
 finish-args:


### PR DESCRIPTION
This PR adds `copy-icon` to the manifest so Tenacity doesn't use the default Wayland icon.

Fixes #34.