### PR TITLE
Refine device permissions

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -13,6 +13,7 @@ finish-args:
   - --share=network # Tenacity uses network sockets for IPC
   - --socket=pulseaudio
   - --device=dri
+  - --device=shm # Needed for IPC
   - --filesystem=host
   # mod-script-pipe provides named pipes in /tmp
   - --filesystem=/tmp


### PR DESCRIPTION
This PR reduces the device permissions given to Tenacity's sandbox to just input and shared memory devices. The intent of this PR is to reduce access to unnecessary devices that Tenacity will not use.

In testing this PR with a Blue Snowball USB mic, compared to a non-Flatpak installation, both ALSA and JACK detect it. Recording also continues to work, while general playback appears to work as well.