### PR TITLE
Update Freedesktop runtime to 25.08

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -1,6 +1,6 @@
 app-id: org.tenacityaudio.Tenacity
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: tenacity.sh
 rename-icon: tenacity


### PR DESCRIPTION
Just some maintenance in keeping up with the latest Freedesktop runtime. Tenacity 1.3.4 should still build around this runtime.

Meanwhile, wxWidgets isn't getting updated in the Flatpak as long as we're on 1.3.4, unless some security vulnerability comes out. Tenacity 1.4 will be on the latest version of wxWidgets again, however.