### PR TITLE
Update to 1.3.5 + update all dependencies

### DIFF
--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -93,8 +93,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/wxWidgets/wxWidgets
-        tag: v3.2.8.1
-        commit: 896e4f587615b832ce27b8325357cb504997e1d3
+        tag: v3.3.3
+        commit: 670835aec7e54b9e9d5a50d6a1aea1e8ba0bcdb2
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
@@ -106,8 +106,8 @@ modules:
     sources:
       - type: git
         url: https://codeberg.org/tenacityteam/libid3tag.git
-        tag: 0.16.3
-        commit: e02ecf1276b467a8a5dd20c55ce711e6f7116d3e
+        tag: 0.16.4
+        commit: fff52d4e27a6f8e3a714bd304e4258d9e1b0dad8
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
@@ -174,8 +174,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/PortMidi/portmidi.git
-        tag: v2.0.4
-        commit: b808babecdc5d05205467dab5c1006c5ac0fdfd4
+        tag: v2.0.8
+        commit: 101dac9455e2718512c94e24cbcae6a6f34b908b
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
@@ -223,8 +223,8 @@ modules:
     sources:
       - type: git
         url: https://codeberg.org/soundtouch/soundtouch.git
-        tag: 2.4.0
-        commit: d994965fbbcf0f6ceeed0e72516968130c2912f0
+        tag: 2.4.1
+        commit: 0047e0b1ecfceb041348579119bf79b73a322a3a
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$

--- a/org.tenacityaudio.Tenacity.yaml
+++ b/org.tenacityaudio.Tenacity.yaml
@@ -254,8 +254,8 @@ modules:
     sources:
       - type: git
         url: https://codeberg.org/tenacityteam/tenacity.git
-        tag: v1.3.4
-        commit: c6eb43e62e0b69d7f0dd7f2871d10a8ebc2d56a7
+        tag: v1.3.5
+        commit: 52ef74db0a2ee8a9e42be1f4a2ff57d90d6564d7
       - type: script
         dest-filename: tenacity.sh
         commands:


### PR DESCRIPTION
This PR updates our Flatpak to 1.3.5. It is also planned to update all other dependencies, including wxWidgets, PortMidi, and others, inside the Flatpak to their latest versions as well. As of now, this hasn't happened yet, but it will once there aren't any issues discovered.